### PR TITLE
fix(doc_win): fix bug when translating on a flow document window.

### DIFF
--- a/lua/kd/init.lua
+++ b/lua/kd/init.lua
@@ -46,6 +46,7 @@ local translate_cmd = "kd"
 
 -- 添加一个全局变量来跟踪当前的翻译窗口
 local current_window = nil
+local cursor_win = nil
 
 -- 获取选中的文本
 local function get_visual_selection()
@@ -208,6 +209,9 @@ function TranslateWindow.new(text)
 	-- 创建窗口
 	self:open()
 
+	-- 设置 autocmds
+	self:setup_autocmds()
+
 	-- 设置按键映射
 	self:setup_keymaps()
 
@@ -216,8 +220,6 @@ end
 
 function TranslateWindow:open()
 	self.winid = api.nvim_open_win(self.bufnr, false, self.win_opts)
-	-- enter the window
-	api.nvim_set_current_win(self.winid)
 	api.nvim_win_set_option(self.winid, "wrap", true)
 	-- 确保窗口中启用语法高亮
 	vim.api.nvim_win_call(self.winid, function()
@@ -232,16 +234,38 @@ function TranslateWindow:setup_keymaps()
 	api.nvim_buf_set_keymap(self.bufnr, "n", "<ESC>", ":q<CR>", opts)
 end
 
+-- 设置 autocmds
+function TranslateWindow:setup_autocmds()
+	api.nvim_create_autocmd({ "CursorMoved" }, {
+		buffer = api.nvim_get_current_buf(),
+		callback = function()
+			self:close()
+		end,
+	})
+
+	api.nvim_create_autocmd({ "WinLeave" }, {
+		buffer = self.bufnr,
+		callback = function()
+			self:close()
+		end,
+	})
+end
+
 ---检查窗口是否有效
 ---@return boolean
 function TranslateWindow:is_valid()
-	return self.winid and api.nvim_win_is_valid(self.winid)
+	if current_window then
+		return self.winid and api.nvim_win_is_valid(self.winid)
+	else
+		return false
+	end
 end
 
 ---关闭窗口
 function TranslateWindow:close()
 	if self:is_valid() then
 		api.nvim_win_close(self.winid, true)
+		current_window = nil
 	end
 end
 
@@ -288,6 +312,15 @@ function M.translate(mode)
 	end)
 end
 
+function M._translate(mode)
+	if current_window and current_window:is_valid() then
+		-- when twice pressed the key, enter the window
+		-- enter the window
+		api.nvim_set_current_win(current_window.winid)
+	else
+		M.translate(mode)
+	end
+end
 -- 修改 setup 函数
 function M.setup(opts)
 	M.config = vim.tbl_deep_extend("force", M.config, opts or {})

--- a/lua/kd/init.lua
+++ b/lua/kd/init.lua
@@ -173,8 +173,6 @@ TranslateWindow.__index = TranslateWindow
 function TranslateWindow.new(text)
 	local self = setmetatable({}, TranslateWindow)
 
-	-- 创建缓冲区
-	self.bufnr = api.nvim_create_buf(false, true)
 	-- 过滤掉包含特定关键字的行
 	local lines = vim.split(text, "\n")
 	local filtered_lines = {}
@@ -183,8 +181,9 @@ function TranslateWindow.new(text)
 			table.insert(filtered_lines, line)
 		end
 	end
+	-- 创建缓冲区
+	self.bufnr = api.nvim_create_buf(false, true)
 	api.nvim_buf_set_lines(self.bufnr, 0, -1, false, filtered_lines)
-
 	-- 设置缓冲区选项
 	api.nvim_buf_set_option(self.bufnr, "modifiable", false)
 	api.nvim_buf_set_option(self.bufnr, "filetype", "kd") -- 这会自动加载我们的语法文件
@@ -203,6 +202,7 @@ function TranslateWindow.new(text)
 	self.win_opts = vim.tbl_extend("force", M.config.window, {
 		width = width,
 		height = height,
+		zindex = 100, -- enable zindex max than that on most common scenes.
 	})
 
 	-- 创建窗口
@@ -215,7 +215,9 @@ function TranslateWindow.new(text)
 end
 
 function TranslateWindow:open()
-	self.winid = api.nvim_open_win(self.bufnr, true, self.win_opts)
+	self.winid = api.nvim_open_win(self.bufnr, false, self.win_opts)
+	-- enter the window
+	api.nvim_set_current_win(self.winid)
 	api.nvim_win_set_option(self.winid, "wrap", true)
 	-- 确保窗口中启用语法高亮
 	vim.api.nvim_win_call(self.winid, function()

--- a/plugin/kd.lua
+++ b/plugin/kd.lua
@@ -4,9 +4,9 @@ local kd = require("kd")
 local command = api.nvim_create_user_command
 
 command("TranslateNormal", function()
-	kd.translate("n")
+	kd._translate("n")
 end, { desc = "Translate selected word" })
 
 command("TranslateVisual", function()
-	kd.translate("v")
+	kd._translate("v")
 end, { desc = "Translate selected word", range = true })

--- a/plugin/kd.lua
+++ b/plugin/kd.lua
@@ -1,10 +1,12 @@
 local api, fn = vim.api, vim.fn
 
-local kd = require 'kd'
+local kd = require("kd")
 local command = api.nvim_create_user_command
 
-command('TranslateNormal', function() kd.translate("n") end,
-    { desc = 'Translate selected word' })
+command("TranslateNormal", function()
+	kd.translate("n")
+end, { desc = "Translate selected word" })
 
-command('TranslateVisual', function() kd.translate("v") end,
-    { desc = 'Translate selected word', range = true })
+command("TranslateVisual", function()
+	kd.translate("v")
+end, { desc = "Translate selected word", range = true })


### PR DESCRIPTION
## 问题

当我在一个文档的浮动窗口翻译的时候，有以下报错：

```
Error executing vim.schedule lua callback: /home/herschel/projects/kd_translate.nvim/lua/kd/init.lua:218: Window was closed immediately
stack traceback:
	[C]: in function 'nvim_open_win'
	/home/herschel/projects/kd_translate.nvim/lua/kd/init.lua:218: in function 'open'
	/home/herschel/projects/kd_translate.nvim/lua/kd/init.lua:209: in function 'new'
	/home/herschel/projects/kd_translate.nvim/lua/kd/init.lua:279: in function </home/herschel/projects/kd_translate.nvim/lua/kd/init.lua:277>
```
![7d480cbd-2cd5-4643-8881-b7267883de42](https://github.com/user-attachments/assets/fe783f5d-c6f8-4808-ae30-602f6e2dfc81)

这个问题貌似是因为调用 `vim.api.nvim_open_win(.., true, ..)`  的时候，异步进入新窗口，触发了 lsp 文档窗口的自动命令销毁之前的窗口导致生命周期紊乱，具体原因不详。

这个pr修复了这个问题，用的方法是取巧的方式，先创建窗口，然后再进入窗口。

![2dda3b17-4963-469f-baa6-c4b42e7f904a](https://github.com/user-attachments/assets/fdc952d1-21b9-489c-b3bd-0d9dfebf467c)
